### PR TITLE
Add kill registration to prevent double counting

### DIFF
--- a/ZodiacBuddy/ConfigWindow.cs
+++ b/ZodiacBuddy/ConfigWindow.cs
@@ -35,6 +35,9 @@ internal class ConfigWindow : Window {
         if (ImGui.CollapsingHeader("Bonus Light"))
             this.DrawBonusLight();
 
+        if (ImGui.CollapsingHeader("Zenith"))
+            this.DrawZenith();
+
         if (ImGui.CollapsingHeader("Atma"))
             this.DrawAtma();
 
@@ -225,9 +228,42 @@ internal class ConfigWindow : Window {
 
         ImGui.Spacing();
     }
+
+    private void DrawZenith() {
+        var showRelicWindow = Service.Configuration.Zenith.DisplayRelicInfo;
+        if (ImGui.Checkbox("Display Zodiac Zenith relic information when equipped", ref showRelicWindow)) {
+            Service.Configuration.Zenith.DisplayRelicInfo = showRelicWindow;
+            Service.Configuration.Save();
+        }
+
+        var showUpgradeProgress = Service.Configuration.Zenith.ShowUpgradeProgress;
+        if (ImGui.Checkbox("Show upgrade progress and tracking", ref showUpgradeProgress)) {
+            Service.Configuration.Zenith.ShowUpgradeProgress = showUpgradeProgress;
+            Service.Configuration.Save();
+        }
+
+        var showMaterialRequirements = Service.Configuration.Zenith.ShowMaterialRequirements;
+        if (ImGui.Checkbox("Show material requirements for next upgrade", ref showMaterialRequirements)) {
+            Service.Configuration.Zenith.ShowMaterialRequirements = showMaterialRequirements;
+            Service.Configuration.Save();
+        }
+
+        ImGui.Spacing();
+    }
     
     private void Debug() {
         if (ImGui.Button("Check duties territory"))
             DebugTools.CheckBonusLightDutyTerritories();
+            
+        if (ImGui.Button("Show equipped weapon info")) {
+            var mainhand = Util.GetEquippedItem(0);
+            var offhand = Util.GetEquippedItem(1);
+            
+            Service.PluginLog.Info($"Mainhand: ID={mainhand.ItemId}");
+            Service.PluginLog.Info($"Offhand: ID={offhand.ItemId}");
+            
+            Service.ChatGui.Print($"[ZodiacBuddy] Mainhand: {mainhand.ItemId}");
+            Service.ChatGui.Print($"[ZodiacBuddy] Offhand: {offhand.ItemId}");
+        }
     }
 }

--- a/ZodiacBuddy/PluginConfiguration.cs
+++ b/ZodiacBuddy/PluginConfiguration.cs
@@ -4,8 +4,10 @@ using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 using ZodiacBuddy.BonusLight;
 using ZodiacBuddy.InformationWindow;
+using ZodiacBuddy.Stages.Atma;
 using ZodiacBuddy.Stages.Brave;
 using ZodiacBuddy.Stages.Novus;
+using ZodiacBuddy.Stages.Zenith;
 
 namespace ZodiacBuddy;
 
@@ -25,6 +27,8 @@ public class PluginConfiguration : IPluginConfiguration {
     public NovusConfiguration Novus { get; } = new();
 
     public BraveConfiguration Brave { get; } = new();
+
+    public ZenithConfiguration Zenith { get; } = new();
 
     public InformationWindowConfiguration InformationWindow { get; } = new();
 

--- a/ZodiacBuddy/Stages/Zenith/ZenithConfiguration.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithConfiguration.cs
@@ -18,4 +18,9 @@ public class ZenithConfiguration {
     /// Gets or sets a value indicating whether to display material requirements.
     /// </summary>
     public bool ShowMaterialRequirements { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether navigation buttons are enabled.
+    /// </summary>
+    public bool EnableNavigation { get; set; } = true;
 }

--- a/ZodiacBuddy/Stages/Zenith/ZenithConfiguration.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithConfiguration.cs
@@ -1,0 +1,21 @@
+namespace ZodiacBuddy.Stages.Zenith;
+
+/// <summary>
+/// Configuration class for Zodiac Zenith relic.
+/// </summary>
+public class ZenithConfiguration {
+    /// <summary>
+    /// Gets or sets a value indicating whether to display the information about the equipped relic.
+    /// </summary>
+    public bool DisplayRelicInfo { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show upgrade progress and material tracking.
+    /// </summary>
+    public bool ShowUpgradeProgress { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to display material requirements.
+    /// </summary>
+    public bool ShowMaterialRequirements { get; set; } = true;
+}

--- a/ZodiacBuddy/Stages/Zenith/ZenithDestinations.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithDestinations.cs
@@ -1,0 +1,35 @@
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+
+namespace ZodiacBuddy.Stages.Zenith;
+
+/// <summary>
+/// Defines navigation destinations for the Zenith stage.
+/// </summary>
+public static class ZenithDestinations {
+    /// <summary>
+    /// The Furnace location in North Shroud (Hyrstmill) where Zenith weapons are upgraded.
+    /// Territory 154 = North Shroud, Aetheryte 7 = Fallgourd Float
+    /// </summary>
+    public static readonly MapLinkPayload Furnace = new(154, 7, 30.0f, 20.0f);
+    
+    /// <summary>
+    /// Auriana in Mor Dhona - Primary vendor for Thavnairian Mist (Allagan Tomestones of Poetics).
+    /// Territory 156 = Mor Dhona, Aetheryte 11 = Revenant's Toll
+    /// </summary>
+    public static readonly MapLinkPayload AurianaPoeticsVendor = new(156, 11, 22.7f, 6.7f);
+    
+    /// <summary>
+    /// Hismena in Idyllshire - Alternative vendor for Thavnairian Mist (Allagan Tomestones of Poetics).
+    /// Territory 478 = Idyllshire, Aetheryte 75 = Idyllshire
+    /// </summary>
+    public static readonly MapLinkPayload HismenaPoeticsVendor = new(478, 75, 5.7f, 5.2f);
+
+    /// <summary>
+    /// Display names for destinations.
+    /// </summary>
+    public static class Names {
+        public const string Furnace = "The Furnace (Hyrstmill, North Shroud)";
+        public const string AurianaPoeticsVendor = "Auriana (Mor Dhona) - Poetics Vendor";
+        public const string HismenaPoeticsVendor = "Hismena (Idyllshire) - Poetics Vendor";
+    }
+}

--- a/ZodiacBuddy/Stages/Zenith/ZenithManager.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithManager.cs
@@ -1,14 +1,43 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Plugin.Services;
+using ECommons;
+using ECommons.Automation;
+using ECommons.Automation.LegacyTaskManager;
+using ECommons.DalamudServices;
+using ECommons.GameHelpers;
+using ECommons.Logging;
+using ECommons.Throttlers;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using Lumina.Excel.Sheets;
+using ZodiacBuddy.Stages.Atma.Movement;
+using ZodiacBuddy.Stages.Atma.Unstuck;
 
 namespace ZodiacBuddy.Stages.Zenith;
 
 /// <summary>
 /// Your buddy for the Zodiac Zenith stage.
 /// </summary>
-internal class ZenithManager : IDisposable {
+public class ZenithManager : IDisposable {
     private readonly ZenithWindow window;
+    private Vector3 _lastPosition;
+    private DateTime _lastMovement = DateTime.Now;
+    private const float MinMovementDistance = 0.2f;
+    private const float NavResetThreshold = 3f;
+    private readonly AdvancedUnstuck _advancedUnstuck;
+    private bool monitoringPathing = false;
+    private DateTime unmountStartTime;
+    private bool restartNavAfterUnstuck = false;
+    private bool hasQueuedMountTasks = false;
+    private bool hasEnteredBetweenAreas = false;
+    private bool awaitingTeleportFromZenithClick = false;
+    private List<Vector3>? _lastKnownPath;
+    private readonly TaskManager TaskManager = new();
 
     /// <summary>
     /// Item ID for Allagan Tomestone of Poetics (commonly used tomestone in 2025)
@@ -19,6 +48,39 @@ internal class ZenithManager : IDisposable {
     /// Item ID for Thavnairian Mist (used for Zenith upgrades)
     /// </summary>
     private const uint ThavnairianMistId = 6268;
+
+    public bool IsPathGenerating => VNavmesh.Nav.PathfindInProgress();
+    public bool IsPathing => VNavmesh.Path.IsRunning();
+    public bool NavReady => VNavmesh.Nav.IsReady();
+
+    public bool CanAct
+    {
+        get
+        {
+            var player = Svc.ClientState.LocalPlayer;
+            if (player == null || player.IsDead || Player.IsAnimationLocked)
+                return false;
+            var c = Svc.Condition;
+            if (c[ConditionFlag.BetweenAreas]
+                || c[ConditionFlag.BetweenAreas51]
+                || c[ConditionFlag.OccupiedInQuestEvent]
+                || c[ConditionFlag.OccupiedSummoningBell]
+                || c[ConditionFlag.BeingMoved]
+                || c[ConditionFlag.Casting]
+                || c[ConditionFlag.Casting87]
+                || c[ConditionFlag.Jumping]
+                || c[ConditionFlag.Jumping61]
+                || c[ConditionFlag.LoggingOut]
+                || c[ConditionFlag.Occupied]
+                || c[ConditionFlag.Occupied39]
+                || c[ConditionFlag.Unconscious]
+                || c[ConditionFlag.ExecutingGatheringAction]
+                || c[ConditionFlag.MountOrOrnamentTransition]
+                || c[85] && !c[ConditionFlag.Gathering])
+                return false;
+            return true;
+        }
+    }
 
     /// <summary>
     /// Gets the current count of Allagan Tomestones of Poetics
@@ -39,9 +101,14 @@ internal class ZenithManager : IDisposable {
     /// </summary>
     public ZenithManager() {
         this.window = new ZenithWindow();
+        this.window.Manager = this; // Wire up reference for navigation
+        _advancedUnstuck = new AdvancedUnstuck();
+        _advancedUnstuck.OnUnstuckComplete += OnUnstuckCompleteHandler;
         
         Service.Framework.Update += this.OnUpdate;
         Service.Interface.UiBuilder.Draw += this.window.Draw;
+        Svc.Framework.Update += _advancedUnstuck.RunningUpdate;
+        Svc.Framework.Update += MonitorUnstuck;
     }
 
     private static ZenithConfiguration Configuration => Service.Configuration.Zenith;
@@ -50,6 +117,10 @@ internal class ZenithManager : IDisposable {
     public void Dispose() {
         Service.Framework.Update -= this.OnUpdate;
         Service.Interface.UiBuilder.Draw -= this.window.Draw;
+        Svc.Framework.Update -= MonitorUnstuck;
+        Svc.Framework.Update -= WaitForBetweenAreasAndExecute;
+        Svc.Framework.Update -= MonitorPathingAndDismount;
+        Svc.Framework.Update -= _advancedUnstuck.RunningUpdate;
     }
 
     private void OnUpdate(IFramework framework) {
@@ -73,5 +144,310 @@ internal class ZenithManager : IDisposable {
         catch (Exception ex) {
             Service.PluginLog.Error(ex, $"Unhandled error during {nameof(ZenithManager)}.{nameof(this.OnUpdate)}");
         }
+    }
+
+    private static uint GetNearestAetheryte(MapLinkPayload mapLink) {
+        var closestAetheryteId = 0u;
+        var closestDistance = double.MaxValue;
+
+        static float ConvertRawPositionToMapCoordinate(int pos, float scale) {
+            var c = scale / 100.0f;
+            var scaledPos = pos * c / 1000.0f;
+
+            return (41.0f / c * ((scaledPos + 1024.0f) / 2048.0f)) + 1.0f;
+        }
+
+        var aetherytes = Service.DataManager.GetExcelSheet<Aetheryte>();
+        var mapMarkers = Service.DataManager.GetSubrowExcelSheet<MapMarker>();
+
+        foreach (var aetheryte in aetherytes) {
+            if (!aetheryte.IsAetheryte)
+                continue;
+
+            if (aetheryte.Territory.Value.RowId != mapLink.TerritoryType.RowId)
+                continue;
+
+            var map = aetheryte.Map.Value;
+            var scale = map.SizeFactor;
+            var name = map.PlaceName.Value.Name.ExtractText();
+
+            var mapMarker = mapMarkers
+                .SelectMany(markers => markers)
+                .FirstOrDefault(m => m.DataType == 3 && m.DataKey.RowId == aetheryte.RowId);
+            
+            if (mapMarker.RowId is 0) {
+                Service.PluginLog.Debug($"Could not find aetheryte: {name}");
+                return 0;
+            }
+
+            var aetherX = ConvertRawPositionToMapCoordinate(mapMarker.X, scale);
+            var aetherY = ConvertRawPositionToMapCoordinate(mapMarker.Y, scale);
+
+            var distance = Math.Pow(aetherX - mapLink.XCoord, 2) + Math.Pow(aetherY - mapLink.YCoord, 2);
+            if (distance < closestDistance)
+            {
+                closestDistance = distance;
+                closestAetheryteId = aetheryte.RowId;
+            }
+        }
+        return closestAetheryteId;
+    }
+
+    private unsafe void Teleport(uint aetheryteId) {
+        if (Service.ClientState.LocalPlayer == null) return;
+        if (Service.Configuration.DisableTeleport) return;
+
+        Telepo.Instance()->Teleport(aetheryteId, 0);
+    }
+
+    public void NavigateToLocation(MapLinkPayload location) {
+        if (!EzThrottler.Throttle("ZenithNavigate", 500))
+            return;
+
+        var aetheryteId = GetNearestAetheryte(location);
+        if (aetheryteId == 0) {
+            Service.PluginLog.Warning($"Could not find an aetheryte for location");
+            return;
+        }
+
+        Service.GameGui.OpenMapWithMapLink(location);
+        this.Teleport(aetheryteId);
+        
+        if (!awaitingTeleportFromZenithClick) {
+            awaitingTeleportFromZenithClick = true;
+            Svc.Framework.Update += WaitForBetweenAreasAndExecute;
+        }
+    }
+
+    private void MonitorUnstuck(IFramework _)
+    {
+        if (!IsPathing || _advancedUnstuck.IsRunning || Player.Object == null)
+            return;
+        var now = DateTime.Now;
+        var currentPos = Player.Object.Position;
+        if (Vector3.Distance(_lastPosition, currentPos) >= MinMovementDistance)
+        {
+            _lastPosition = currentPos;
+            _lastMovement = now;
+        }
+        else if ((now - _lastMovement).TotalSeconds > NavResetThreshold)
+        {
+            Service.PluginLog.Debug($"AdvancedUnstuck: stuck detected. Moved {Vector3.Distance(_lastPosition, currentPos)} yalms in {(now - _lastMovement).TotalSeconds:F1} seconds.");
+            restartNavAfterUnstuck = true;
+            _advancedUnstuck.Start();
+            _lastMovement = now;
+        }
+    }
+
+    internal void WaitForBetweenAreasAndExecute(IFramework framework)
+    {
+        if (!awaitingTeleportFromZenithClick)
+            return;
+        if (!hasEnteredBetweenAreas)
+        {
+            if (Svc.Condition[ConditionFlag.BetweenAreas])
+            {
+                hasEnteredBetweenAreas = true;
+            }
+        }
+        else
+        {
+            if (!Svc.Condition[ConditionFlag.BetweenAreas] && GenericHelpers.IsScreenReady() && !hasQueuedMountTasks)
+            {
+                hasQueuedMountTasks = true;
+                EnqueueMountUp();
+            }
+        }
+    }
+
+    private unsafe void EnqueueMountUp()
+    {
+        TaskManager.Enqueue(() => NavReady);
+
+        TaskManager.Enqueue(() =>
+        {
+            if (Svc.Condition[ConditionFlag.Mounted])
+            {
+                Service.PluginLog.Debug("Already mounted, skipping mount roulette use.");
+                return true;
+            }
+            var am = ActionManager.Instance();
+            const uint rouletteId = 9;
+            if (am->GetActionStatus(ActionType.GeneralAction, rouletteId) == 0)
+            {
+                Service.PluginLog.Debug("Attempting to use mount roulette...");
+                if (am->UseAction(ActionType.GeneralAction, rouletteId))
+                {
+                    Service.PluginLog.Debug("Using mount roulette.");
+                }
+                else
+                {
+                    Service.PluginLog.Warning("Failed to use mount roulette.");
+                }
+            }
+            else
+            {
+                Service.PluginLog.Warning("Mount roulette unavailable.");
+            }
+            return true;
+        });
+        TaskManager.Enqueue(() =>
+        {
+            if (_advancedUnstuck.IsRunning)
+            {
+                Service.PluginLog.Debug("Skipping wait for mounted because AdvancedUnstuck active.");
+                return true;
+            }
+            return Svc.Condition[ConditionFlag.Mounted];
+        });
+        TaskManager.Enqueue(() =>
+        {   
+            Chat.ExecuteCommand("/vnav flyflag");
+            EnqueueUnmountAfterNav();
+            hasEnteredBetweenAreas = false;
+            awaitingTeleportFromZenithClick = false;
+            hasQueuedMountTasks = false;
+            return true;
+        });
+    }
+
+    public unsafe void EnqueueUnmountAfterNav()
+    {
+        if (monitoringPathing) return;
+        monitoringPathing = true;
+        unmountStartTime = DateTime.Now;
+        Svc.Framework.Update += MonitorPathingAndDismount;
+    }
+
+    private unsafe void MonitorPathingAndDismount(IFramework _)
+    {
+        if (_advancedUnstuck.IsRunning)
+            return;
+        if (VNavmesh.Nav.PathfindInProgress() || VNavmesh.Path.IsRunning())
+            return;
+        if (!monitoringPathing)
+            return;
+        monitoringPathing = false;
+        Svc.Framework.Update -= MonitorPathingAndDismount;
+        if (restartNavAfterUnstuck)
+        {
+            restartNavAfterUnstuck = false;
+            RestartNavigationToTarget();
+        }
+        else
+        {
+            EnqueueDismount();
+
+            TaskManager.Enqueue(() =>
+            {
+                if (Svc.Condition[ConditionFlag.Mounted])
+                {
+                    Service.PluginLog.Debug("[ZodiacBuddy] Player still mounted after dismount tasks. Waiting another tick.");
+                    return false;
+                }
+
+                if (VNavmesh.Path.IsRunning())
+                {
+                    Service.PluginLog.Debug("[ZodiacBuddy] Navmesh is still running after dismount tasks. Waiting another tick.");
+                    return false;
+                }
+
+                Service.PluginLog.Debug("[ZodiacBuddy] Player dismounted and navmesh idle. Unlocking pathing.");
+                return true;
+            });
+        }
+    }
+
+    private void RestartNavigationToTarget()
+    {
+        VNavmesh.Path.Stop();
+        Chat.ExecuteCommand($"/vnavmesh moveflag");
+        monitoringPathing = true;
+        Svc.Framework.Update += MonitorPathingAndDismount;
+    }
+
+    private unsafe void EnqueueDismount()
+    {
+        if (_advancedUnstuck.IsRunning)
+        {
+            Service.PluginLog.Debug("Skipping dismount because AdvancedUnstuck is active.");
+            return;
+        }
+        var am = ActionManager.Instance();
+        TaskManager.Enqueue(() =>
+        {
+            if (Svc.Condition[ConditionFlag.Mounted])
+                am->UseAction(ActionType.Mount, 0);
+        }, "Dismount");
+        TaskManager.Enqueue(() =>
+        {
+            if (_advancedUnstuck.IsRunning)
+            {
+                Service.PluginLog.Debug("Skipping Wait for not in flight because AdvancedUnstuck active.");
+                return true;
+            }
+            return !Svc.Condition[ConditionFlag.InFlight] && CanAct;
+        }, 1000, "Wait for not in flight");
+        TaskManager.Enqueue(() =>
+        {
+            if (Svc.Condition[ConditionFlag.Mounted])
+                am->UseAction(ActionType.Mount, 0);
+        }, "Dismount 2");
+        TaskManager.Enqueue(() =>
+        {
+            if (_advancedUnstuck.IsRunning)
+            {
+                Service.PluginLog.Debug("Skipping Wait for dismount because AdvancedUnstuck active.");
+                return true;
+            }
+            return !Svc.Condition[ConditionFlag.Mounted] && CanAct;
+        }, 1000, "Wait for dismount");
+        TaskManager.Enqueue(() =>
+        {
+            if (!Svc.Condition[ConditionFlag.Mounted])
+                TaskManager.DelayNextImmediate(500);
+        });
+    }
+
+    private void OnUnstuckCompleteHandler()
+    {
+        Service.PluginLog.Debug("Unstuck finished, restarting navigation.");
+        RestartNavigationToTarget();
+    }
+
+    private void MoveToWithTracking(Vector3 destination)
+    {
+        _lastKnownPath = new List<Vector3> { destination };
+        VNavmesh.Path.MoveTo(_lastKnownPath, false);
+    }
+
+    public void StopNavigation()
+    {
+        Service.PluginLog.Debug("Stopping Zenith navigation...");
+        
+        // Stop VNavmesh pathfinding
+        VNavmesh.Path.Stop();
+        
+        // Clear task queue
+        TaskManager.Abort();
+        
+        // Reset states
+        awaitingTeleportFromZenithClick = false;
+        hasEnteredBetweenAreas = false;
+        hasQueuedMountTasks = false;
+        monitoringPathing = false;
+        restartNavAfterUnstuck = false;
+        
+        // Unregister event handlers
+        Svc.Framework.Update -= WaitForBetweenAreasAndExecute;
+        Svc.Framework.Update -= MonitorPathingAndDismount;
+        
+        // Stop unstuck if running
+        if (_advancedUnstuck.IsRunning)
+        {
+            _advancedUnstuck.Dispose();
+        }
+        
+        Service.PluginLog.Debug("Zenith navigation stopped.");
     }
 }

--- a/ZodiacBuddy/Stages/Zenith/ZenithManager.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithManager.cs
@@ -1,0 +1,77 @@
+using System;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace ZodiacBuddy.Stages.Zenith;
+
+/// <summary>
+/// Your buddy for the Zodiac Zenith stage.
+/// </summary>
+internal class ZenithManager : IDisposable {
+    private readonly ZenithWindow window;
+
+    /// <summary>
+    /// Item ID for Allagan Tomestone of Poetics (commonly used tomestone in 2025)
+    /// </summary>
+    private const uint TomestoneOfPoeticsId = 28;
+
+    /// <summary>
+    /// Item ID for Thavnairian Mist (used for Zenith upgrades)
+    /// </summary>
+    private const uint ThavnairianMistId = 6268;
+
+    /// <summary>
+    /// Gets the current count of Allagan Tomestones of Poetics
+    /// </summary>
+    public static unsafe int GetTomestoneCount() {
+        return (int)InventoryManager.Instance()->GetInventoryItemCount(TomestoneOfPoeticsId);
+    }
+
+    /// <summary>
+    /// Gets the current count of Thavnairian Mist
+    /// </summary>
+    public static unsafe int GetThavnairianMistCount() {
+        return (int)InventoryManager.Instance()->GetInventoryItemCount(ThavnairianMistId);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ZenithManager"/> class.
+    /// </summary>
+    public ZenithManager() {
+        this.window = new ZenithWindow();
+        
+        Service.Framework.Update += this.OnUpdate;
+        Service.Interface.UiBuilder.Draw += this.window.Draw;
+    }
+
+    private static ZenithConfiguration Configuration => Service.Configuration.Zenith;
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        Service.Framework.Update -= this.OnUpdate;
+        Service.Interface.UiBuilder.Draw -= this.window.Draw;
+    }
+
+    private void OnUpdate(IFramework framework) {
+        try {
+            if (!Configuration.DisplayRelicInfo) {
+                this.window.ShowWindow = false;
+                return;
+            }
+
+            var mainhand = Util.GetEquippedItem(0);
+            var offhand = Util.GetEquippedItem(1);
+
+            var shouldShowWindow =
+                ZenithRelic.Items.ContainsKey(mainhand.ItemId) ||
+                ZenithRelic.Items.ContainsKey(offhand.ItemId);
+
+            this.window.ShowWindow = shouldShowWindow;
+            this.window.MainHandItem = mainhand;
+            this.window.OffhandItem = offhand;
+        }
+        catch (Exception ex) {
+            Service.PluginLog.Error(ex, $"Unhandled error during {nameof(ZenithManager)}.{nameof(this.OnUpdate)}");
+        }
+    }
+}

--- a/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+using Lumina.Excel.Sheets;
+
+namespace ZodiacBuddy.Stages.Zenith;
+
+/// <summary>
+/// Define the Zenith relic item Id and their names.
+/// </summary>
+public static class ZenithRelic {
+    /// <summary>
+    /// List of Zodiac Zenith weapons and base relics (for testing).
+    /// </summary>
+    public static readonly Dictionary<uint, string> Items = new() {
+        // Zenith weapons (placeholder IDs - need to be updated with correct values)
+        { 6565, GetItemName(6565) }, // Curtana Zenith
+        { 6566, GetItemName(6566) }, // Sphairai Zenith
+        { 6567, GetItemName(6567) }, // Bravura Zenith
+        { 6568, GetItemName(6568) }, // Gae Bolg Zenith
+        { 6569, GetItemName(6569) }, // Artemis Bow Zenith
+        { 6570, GetItemName(6570) }, // Thyrse Zenith
+        { 6571, GetItemName(6571) }, // Stardust Rod Zenith
+        { 6572, GetItemName(6572) }, // The Veil of Wiyu Zenith
+        { 6573, GetItemName(6573) }, // Omnilex Zenith
+        { 6574, GetItemName(6574) }, // Holy Shield Zenith
+        { 6575, GetItemName(6575) }, // Yoshimitsu Zenith
+        
+        // Base relics (for testing purposes - will show Zenith info for base weapons)
+        // TODO: Remove these once correct Zenith IDs are found
+        { 2052, GetItemName(2052) }, // Thyrus (base relic for testing) - CORRECT ID
+        { 2046, GetItemName(2046) }, // Curtana (base relic)
+        { 2047, GetItemName(2047) }, // Sphairai (base relic)
+        { 2048, GetItemName(2048) }, // Bravura (base relic)
+        { 2049, GetItemName(2049) }, // Gae Bolg (base relic)
+        { 2050, GetItemName(2050) }, // Artemis Bow (base relic)
+        { 2051, GetItemName(2051) }, // Stardust Rod (base relic)
+        { 2053, GetItemName(2053) }, // The Veil of Wiyu (base relic)
+        { 2054, GetItemName(2054) }, // Omnilex (base relic)
+        { 2055, GetItemName(2055) }, // Holy Shield (base relic)
+        { 2056, GetItemName(2056) }, // Yoshimitsu (base relic)
+    };
+
+    private static string GetItemName(uint itemId) {
+        return Service.DataManager.Excel.GetSheet<Item>()
+            .GetRow(itemId).Name
+            .ExtractText();
+    }
+}

--- a/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
@@ -9,34 +9,21 @@ namespace ZodiacBuddy.Stages.Zenith;
 /// </summary>
 public static class ZenithRelic {
     /// <summary>
-    /// List of Zodiac Zenith weapons and base relics (for testing).
+    /// List of base relic weapons that can be upgraded to Zenith.
     /// </summary>
     public static readonly Dictionary<uint, string> Items = new() {
-        // Zenith weapons (correct IDs)
-        { 6257, GetItemName(6257) }, // Curtana Zenith
-        { 6258, GetItemName(6258) }, // Sphairai Zenith
-        { 6259, GetItemName(6259) }, // Bravura Zenith
-        { 6260, GetItemName(6260) }, // Gae Bolg Zenith
-        { 6261, GetItemName(6261) }, // Artemis Bow Zenith
-        { 6262, GetItemName(6262) }, // Thyrus Zenith
-        { 6263, GetItemName(6263) }, // Stardust Rod Zenith
-        { 6264, GetItemName(6264) }, // The Veil of Wiyu Zenith
-        { 6265, GetItemName(6265) }, // Omnilex Zenith
-        { 6266, GetItemName(6266) }, // Holy Shield Zenith
-        { 9250, GetItemName(9250) }, // Yoshimitsu Zenith
-        
-        // Base relics (show Zenith info when base weapons are equipped)
-        { 2052, GetItemName(2052) }, // Thyrus (base relic)
-        { 2046, GetItemName(2046) }, // Curtana (base relic)
-        { 2047, GetItemName(2047) }, // Sphairai (base relic)
-        { 2048, GetItemName(2048) }, // Bravura (base relic)
-        { 2049, GetItemName(2049) }, // Gae Bolg (base relic)
-        { 2050, GetItemName(2050) }, // Artemis Bow (base relic)
-        { 2051, GetItemName(2051) }, // Stardust Rod (base relic)
-        { 2053, GetItemName(2053) }, // The Veil of Wiyu (base relic)
-        { 2054, GetItemName(2054) }, // Omnilex (base relic)
-        { 2055, GetItemName(2055) }, // Holy Shield (base relic)
-        { 2056, GetItemName(2056) }, // Yoshimitsu (base relic)
+        // Base relics (show Zenith upgrade info when these base weapons are equipped)
+        { 2046, GetItemName(2046) }, // Curtana (base relic) → Curtana Zenith
+        { 2047, GetItemName(2047) }, // Sphairai (base relic) → Sphairai Zenith
+        { 2048, GetItemName(2048) }, // Bravura (base relic) → Bravura Zenith
+        { 2049, GetItemName(2049) }, // Gae Bolg (base relic) → Gae Bolg Zenith
+        { 2050, GetItemName(2050) }, // Artemis Bow (base relic) → Artemis Bow Zenith
+        { 2051, GetItemName(2051) }, // Stardust Rod (base relic) → Stardust Rod Zenith
+        { 2052, GetItemName(2052) }, // Thyrus (base relic) → Thyrus Zenith
+        { 2053, GetItemName(2053) }, // The Veil of Wiyu (base relic) → The Veil of Wiyu Zenith
+        { 2054, GetItemName(2054) }, // Omnilex (base relic) → Omnilex Zenith
+        { 2055, GetItemName(2055) }, // Holy Shield (base relic) → Holy Shield Zenith
+        { 2056, GetItemName(2056) }, // Yoshimitsu (base relic) → Yoshimitsu Zenith
     };
 
     private static string GetItemName(uint itemId) {

--- a/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithRelic.cs
@@ -12,22 +12,21 @@ public static class ZenithRelic {
     /// List of Zodiac Zenith weapons and base relics (for testing).
     /// </summary>
     public static readonly Dictionary<uint, string> Items = new() {
-        // Zenith weapons (placeholder IDs - need to be updated with correct values)
-        { 6565, GetItemName(6565) }, // Curtana Zenith
-        { 6566, GetItemName(6566) }, // Sphairai Zenith
-        { 6567, GetItemName(6567) }, // Bravura Zenith
-        { 6568, GetItemName(6568) }, // Gae Bolg Zenith
-        { 6569, GetItemName(6569) }, // Artemis Bow Zenith
-        { 6570, GetItemName(6570) }, // Thyrse Zenith
-        { 6571, GetItemName(6571) }, // Stardust Rod Zenith
-        { 6572, GetItemName(6572) }, // The Veil of Wiyu Zenith
-        { 6573, GetItemName(6573) }, // Omnilex Zenith
-        { 6574, GetItemName(6574) }, // Holy Shield Zenith
-        { 6575, GetItemName(6575) }, // Yoshimitsu Zenith
+        // Zenith weapons (correct IDs)
+        { 6257, GetItemName(6257) }, // Curtana Zenith
+        { 6258, GetItemName(6258) }, // Sphairai Zenith
+        { 6259, GetItemName(6259) }, // Bravura Zenith
+        { 6260, GetItemName(6260) }, // Gae Bolg Zenith
+        { 6261, GetItemName(6261) }, // Artemis Bow Zenith
+        { 6262, GetItemName(6262) }, // Thyrus Zenith
+        { 6263, GetItemName(6263) }, // Stardust Rod Zenith
+        { 6264, GetItemName(6264) }, // The Veil of Wiyu Zenith
+        { 6265, GetItemName(6265) }, // Omnilex Zenith
+        { 6266, GetItemName(6266) }, // Holy Shield Zenith
+        { 9250, GetItemName(9250) }, // Yoshimitsu Zenith
         
-        // Base relics (for testing purposes - will show Zenith info for base weapons)
-        // TODO: Remove these once correct Zenith IDs are found
-        { 2052, GetItemName(2052) }, // Thyrus (base relic for testing) - CORRECT ID
+        // Base relics (show Zenith info when base weapons are equipped)
+        { 2052, GetItemName(2052) }, // Thyrus (base relic)
         { 2046, GetItemName(2046) }, // Curtana (base relic)
         { 2047, GetItemName(2047) }, // Sphairai (base relic)
         { 2048, GetItemName(2048) }, // Bravura (base relic)

--- a/ZodiacBuddy/Stages/Zenith/ZenithWindow.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithWindow.cs
@@ -1,0 +1,68 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+using ImGuiNET;
+using ZodiacBuddy.InformationWindow;
+
+namespace ZodiacBuddy.Stages.Zenith;
+
+/// <summary>
+/// Zenith information window.
+/// </summary>
+public class ZenithWindow() : InformationWindow.InformationWindow("Zodiac Zenith Information") {
+    private static InformationWindowConfiguration InfoWindowConfiguration => Service.Configuration.InformationWindow;
+
+    /// <inheritdoc/>
+    protected override void DisplayRelicInfo(InventoryItem item) {
+        if (!ZenithRelic.Items.TryGetValue(item.ItemId, out var name))
+            return;
+
+        name = name
+            .Replace("Œ", "Oe")
+            .Replace("œ", "oe");
+        ImGui.Text(name);
+
+        ImGui.PushStyleColor(ImGuiCol.PlotHistogram, InfoWindowConfiguration.ProgressColor);
+
+        // Display basic information about the Zenith weapon
+        ImGui.Text("Zenith Stage - Item Level 90");
+        ImGui.Text("Next: Atma Stage");
+        
+        // Show upgrade instructions
+        if (Service.Configuration.Zenith.ShowMaterialRequirements) {
+            ImGui.Separator();
+            ImGui.Text("Upgrade Requirements:");
+            
+            var tomestoneCount = ZenithManager.GetTomestoneCount();
+            var mistCount = ZenithManager.GetThavnairianMistCount();
+            var requiredMists = 3;
+            
+            // Display Thavnairian Mist requirement with current count
+            if (mistCount >= requiredMists) {
+                ImGui.PushStyleColor(ImGuiCol.Text, 0xFF00FF00); // Green
+                ImGui.Text($"✓ 3x Thavnairian Mist ({mistCount}/{requiredMists})");
+                ImGui.PopStyleColor();
+            } else {
+                ImGui.PushStyleColor(ImGuiCol.Text, 0xFF0000FF); // Red
+                ImGui.Text($"• 3x Thavnairian Mist ({mistCount}/{requiredMists})");
+                ImGui.PopStyleColor();
+                
+                // Show tomestone count if we need to buy more mists
+                var neededMists = requiredMists - mistCount;
+                var neededTomestones = neededMists * 20;
+                
+                if (tomestoneCount >= neededTomestones) {
+                    ImGui.PushStyleColor(ImGuiCol.Text, 0xFF00FFFF); // Yellow
+                    ImGui.Text($"  ✓ {neededTomestones} Tomestones of Poetics ({tomestoneCount} available)");
+                    ImGui.PopStyleColor();
+                } else {
+                    ImGui.PushStyleColor(ImGuiCol.Text, 0xFF0000FF); // Red
+                    ImGui.Text($"  Need {neededTomestones} Tomestones of Poetics ({tomestoneCount}/{neededTomestones})");
+                    ImGui.PopStyleColor();
+                }
+            }
+            
+            ImGui.Text("• Visit Furnace in Central Thanalan");
+        }
+
+        ImGui.PopStyleColor();
+    }
+}

--- a/ZodiacBuddy/Stages/Zenith/ZenithWindow.cs
+++ b/ZodiacBuddy/Stages/Zenith/ZenithWindow.cs
@@ -9,6 +9,11 @@ namespace ZodiacBuddy.Stages.Zenith;
 /// </summary>
 public class ZenithWindow() : InformationWindow.InformationWindow("Zodiac Zenith Information") {
     private static InformationWindowConfiguration InfoWindowConfiguration => Service.Configuration.InformationWindow;
+    
+    /// <summary>
+    /// Reference to the ZenithManager for navigation functionality.
+    /// </summary>
+    public ZenithManager? Manager { get; set; }
 
     /// <inheritdoc/>
     protected override void DisplayRelicInfo(InventoryItem item) {
@@ -22,14 +27,14 @@ public class ZenithWindow() : InformationWindow.InformationWindow("Zodiac Zenith
 
         ImGui.PushStyleColor(ImGuiCol.PlotHistogram, InfoWindowConfiguration.ProgressColor);
 
-        // Display basic information about the Zenith weapon
-        ImGui.Text("Zenith Stage - Item Level 90");
-        ImGui.Text("Next: Atma Stage");
+        // Display upgrade information
+        ImGui.Text("Ready to upgrade to Zenith (Item Level 90)");
+        ImGui.Text("After Zenith: Atma Stage");
         
         // Show upgrade instructions
         if (Service.Configuration.Zenith.ShowMaterialRequirements) {
             ImGui.Separator();
-            ImGui.Text("Upgrade Requirements:");
+            ImGui.Text("Requirements to upgrade to Zenith:");
             
             var tomestoneCount = ZenithManager.GetTomestoneCount();
             var mistCount = ZenithManager.GetThavnairianMistCount();
@@ -60,7 +65,34 @@ public class ZenithWindow() : InformationWindow.InformationWindow("Zodiac Zenith
                 }
             }
             
-            ImGui.Text("• Visit Furnace in Central Thanalan");
+            ImGui.Text("• Bring materials to The Furnace in North Shroud (Hyrstmill)");
+            
+            // Navigation buttons
+            if (Service.Configuration.Zenith.EnableNavigation) {
+                ImGui.Separator();
+                ImGui.Text("Navigation:");
+                
+                if (ImGui.Button("Go to Furnace for Upgrade##ZenithFurnace")) {
+                    Manager?.NavigateToLocation(ZenithDestinations.Furnace);
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Stop Navigation##ZenithStop")) {
+                    Manager?.StopNavigation();
+                }
+                
+                // Vendor navigation for materials
+                if (mistCount < requiredMists) {
+                    ImGui.Spacing();
+                    ImGui.Text("Get Thavnairian Mist:");
+                    if (ImGui.Button("Auriana (Mor Dhona)##ZenithAuriana")) {
+                        Manager?.NavigateToLocation(ZenithDestinations.AurianaPoeticsVendor);
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("Hismena (Idyllshire)##ZenithHismena")) {
+                        Manager?.NavigateToLocation(ZenithDestinations.HismenaPoeticsVendor);
+                    }
+                }
+            }
         }
 
         ImGui.PopStyleColor();

--- a/ZodiacBuddy/TargetingHelper.cs
+++ b/ZodiacBuddy/TargetingHelper.cs
@@ -7,6 +7,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Common.Math;
 using System;
+using System.Collections.Generic;
 using static FFXIVClientStructs.FFXIV.Client.Game.UI.MobHunt;
 
 namespace ZodiacBuddy.Helpers;
@@ -17,6 +18,7 @@ public static unsafe class TargetingHelper
     private static int _killCount = 0;
     private static ulong _lastKilledId = 0;
     private static string? _killTrackingTarget = null;
+    private static readonly HashSet<ulong> _registeredKills = new();
     public static int KillCount => _killCount;
     public static void RegisterKillIfMatches(ulong killedId, string currentTargetName)
     {
@@ -24,8 +26,9 @@ public static unsafe class TargetingHelper
             return;
 
         if (_killTrackingTarget.Equals(currentTargetName, StringComparison.OrdinalIgnoreCase)
-            && killedId != 0 && killedId != _lastKilledId)
+            && killedId != 0 && !_registeredKills.Contains(killedId))
         {
+            _registeredKills.Add(killedId);
             _killCount++;
             _lastKilledId = killedId;
             Service.PluginLog.Debug($"Registered kill for enemy '{currentTargetName}'. Total: {_killCount}");
@@ -36,6 +39,7 @@ public static unsafe class TargetingHelper
         _killTrackingTarget = targetName;
         _killCount = 0;
         _lastKilledId = 0;
+        _registeredKills.Clear();
         _hasAutoTargeted = false;
     }
 

--- a/ZodiacBuddy/ZodiacBuddyPlugin.cs
+++ b/ZodiacBuddy/ZodiacBuddyPlugin.cs
@@ -8,6 +8,7 @@ using ZodiacBuddy.BonusLight;
 using ZodiacBuddy.Stages.Atma;
 using ZodiacBuddy.Stages.Brave;
 using ZodiacBuddy.Stages.Novus;
+using ZodiacBuddy.Stages.Zenith;
 using ECommons;
 using ECommons.DalamudServices;
 
@@ -23,6 +24,7 @@ public sealed class ZodiacBuddyPlugin : IDalamudPlugin {
     private readonly AtmaManager animusBuddy;
     private readonly NovusManager novusManager;
     private readonly BraveManager braveManager;
+    private readonly ZenithManager zenithManager;
     private readonly WindowSystem windowSystem;
     internal TargetInfoWindow TargetWindow;
 
@@ -61,6 +63,7 @@ public sealed class ZodiacBuddyPlugin : IDalamudPlugin {
         this.animusBuddy = new AtmaManager();
         this.novusManager = new NovusManager();
         this.braveManager = new BraveManager();
+        this.zenithManager = new ZenithManager();
         this.atma = new AtmaManager();
         AtmaManager.OnFallbackPathIssued = () => atma.EnqueueUnmountAfterNav();
 
@@ -79,6 +82,7 @@ public sealed class ZodiacBuddyPlugin : IDalamudPlugin {
         this.animusBuddy.Dispose();
         this.novusManager.Dispose();
         this.braveManager.Dispose();
+        this.zenithManager.Dispose();
         Service.BonusLightManager.Dispose();
         ECommons.ECommonsMain.Dispose();
     }


### PR DESCRIPTION
This pull request introduces enhancements to the `TargetingHelper` class in `ZodiacBuddy` to improve kill tracking functionality. The changes include adding a mechanism to prevent duplicate kill registrations and ensuring proper state reset when starting kill tracking.

### Improvements to kill tracking:

* Introduced a `HashSet<ulong>` named `_registeredKills` to track unique kill IDs, preventing duplicate registrations for the same target. (`ZodiacBuddy/TargetingHelper.cs`, [ZodiacBuddy/TargetingHelper.csR21-R31](diffhunk://#diff-2a2f960ae3230ddd7c0fcd331f6a64a07d5aefc0f1ccb84e966423c08e70f329R21-R31))
* Updated the `StartKillTracking` method to clear the `_registeredKills` set, ensuring a clean state when kill tracking is restarted. (`ZodiacBuddy/TargetingHelper.cs`, [ZodiacBuddy/TargetingHelper.csR42](diffhunk://#diff-2a2f960ae3230ddd7c0fcd331f6a64a07d5aefc0f1ccb84e966423c08e70f329R42))

### Codebase enhancements:

* Added `System.Collections.Generic` to the `using` directives to support the `HashSet` implementation. (`ZodiacBuddy/TargetingHelper.cs`, [ZodiacBuddy/TargetingHelper.csR10](diffhunk://#diff-2a2f960ae3230ddd7c0fcd331f6a64a07d5aefc0f1ccb84e966423c08e70f329R10))